### PR TITLE
9119 - Handle 0 manual transaction total validation issue

### DIFF
--- a/src/composables/ViewRoutingSlip/useRoutingSlipTransaction.ts
+++ b/src/composables/ViewRoutingSlip/useRoutingSlipTransaction.ts
@@ -155,7 +155,7 @@ export default function useRoutingSlipTransaction () {
   function updateAvailableAmountForManualTransaction (): void {
     // We dont need the first item as it would have the entire remainingAmount of the routingslip
     for (let i = 1; i <= manualTransactionsList.value.length - 1; i++) {
-      // if previous slip has no total, then the available amount is carried over to the next slip
+      // if previous record has no total, then the available amount is carried over to the next record
       if (manualTransactionsList.value[i - 1].total > 0) {
         manualTransactionsList.value[i].availableAmountForManualTransaction = routingSlip.value.remainingAmount - manualTransactionsList.value[i - 1].total
       } else {


### PR DESCRIPTION
*Issue #:* /bcgov/entity/9119

*Description of changes:*

- When previous transaction is 0 then we carry over its remaining amount to next record


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
