### PR TITLE
9927 - Add Cheque Advice during Refund Request process

### DIFF
--- a/src/components/ViewRoutingSlip/RefundRequestForm.vue
+++ b/src/components/ViewRoutingSlip/RefundRequestForm.vue
@@ -1,25 +1,51 @@
 <template>
   <v-form ref="refundRequestForm">
-    <v-text-field
-    filled
-    label="Name of Person or Organization"
-    persistent-hint
-    v-model.trim="name"
-    data-test="txtName"
-    :rules="nameRules"
-    v-if="isEditing"
-    >
-    </v-text-field>
-    <span v-else>{{ name }}</span>
-    <address-form
-      ref="addressForm"
-      :editing="isEditing"
-      :schema="baseAddressSchema"
-      :address="address"
-      @update:address="address=$event"
-      @valid="addressValidity"
-    >
-    </address-form>
+    <v-row>
+      <v-col class="col-3 font-weight-bold pb-0">
+        {{ 'Name of Person or Organization & Address' }}
+      </v-col>
+      <v-col class="col-9 pb-0">
+        <v-text-field
+        filled
+        label="Name of Person or Organization"
+        persistent-hint
+        v-model.trim="name"
+        data-test="txtName"
+        :rules="nameRules"
+        v-if="isEditing"
+        >
+        </v-text-field>
+        <span v-else>{{ name }}</span>
+        <address-form
+          ref="addressForm"
+          :editing="isEditing"
+          :schema="baseAddressSchema"
+          :address="address"
+          @update:address="address=$event"
+          @valid="addressValidity"
+        >
+        </address-form>
+      </v-col>
+      <v-col class="col-3 font-weight-bold"
+        :class="isEditing ? 'pt-0' : ''">
+        Cheque Advice
+      </v-col>
+      <v-col
+        class="col-9"
+        :class="isEditing ? 'pt-0' : ''">
+        <v-text-field
+        filled
+        label="Additional Information"
+        persistent-hint
+        v-model.trim="chequeAdvice"
+        data-test="txtChequeAdvice"
+        :rules="chequeAdviceRules"
+        v-if="isEditing"
+        >
+        </v-text-field>
+        <span v-else>{{ chequeAdvice }}</span>
+      </v-col>
+    </v-row>
   </v-form>
 </template>
 <script lang="ts">
@@ -37,7 +63,9 @@ import { RefundRequestDetails } from '@/models/RoutingSlip'
       baseAddressSchema,
       refundRequestForm,
       nameRules,
+      chequeAdviceRules,
       name,
+      chequeAdvice,
       address,
       addressForm,
       addressValidity,
@@ -48,11 +76,13 @@ import { RefundRequestDetails } from '@/models/RoutingSlip'
       baseAddressSchema,
       refundRequestForm,
       nameRules,
+      chequeAdviceRules,
       name,
+      chequeAdvice,
       address,
       addressForm,
-      isValid,
-      addressValidity
+      addressValidity,
+      isValid
     }
   }
 })

--- a/src/components/ViewRoutingSlip/RoutingSlipInfo.vue
+++ b/src/components/ViewRoutingSlip/RoutingSlipInfo.vue
@@ -77,20 +77,15 @@
               </v-row>
             </template>
             <v-expand-transition>
-              <v-row v-if="showAddress">
-                <v-col class="col-3 font-weight-bold">
-                  Name of Person or Organization & Address
-                </v-col>
-                <v-col class="col-9">
-                  <refund-request-form
-                    ref="refundRequestForm"
-                    :inputRefundRequestDetails="refundRequestDetails"
-                    :isEditing="showAddressEditMode"
-                    @update:refundRequestDetails="refundRequestDetails = $event"
-                  >
-                  </refund-request-form>
-                </v-col>
-              </v-row>
+              <template v-if="showAddress">
+                <refund-request-form
+                  ref="refundRequestForm"
+                  :inputRefundRequestDetails="refundRequestDetails"
+                  :isEditing="showAddressEditMode"
+                  @update:refundRequestDetails="refundRequestDetails = $event"
+                >
+                </refund-request-form>
+              </template>
             </v-expand-transition>
 
             <v-row>

--- a/src/composables/ViewRoutingSlip/useRefundRequestForm.ts
+++ b/src/composables/ViewRoutingSlip/useRefundRequestForm.ts
@@ -17,9 +17,11 @@ export default function useRefundRequestForm (props, context) {
   const addressForm = ref<HTMLFormElement>()
 
   const nameRules = CommonUtils.requiredFieldRule()
+  const chequeAdviceRules = CommonUtils.optionalFieldRule('This field should be maximum of 40 characters', 40)
 
   const name = ref<string>('')
   const address = ref<Address>(undefined)
+  const chequeAdvice = ref<string>('')
 
   function addressValidity (isValid: boolean): void {
     isAddressValid.value = isValid
@@ -32,8 +34,8 @@ export default function useRefundRequestForm (props, context) {
   }
 
   // watch input elements name and address, and if anything changes, bubble up the values back to parent;
-  watch([name, address], () => {
-    const refundRequestDetails: RefundRequestDetails = { name: name.value, mailingAddress: address.value } as RefundRequestDetails
+  watch([name, address, chequeAdvice], () => {
+    const refundRequestDetails: RefundRequestDetails = { name: name.value, mailingAddress: address.value, chequeAdvice: chequeAdvice.value } as RefundRequestDetails
     context.emit('update:refundRequestDetails', refundRequestDetails)
   })
 
@@ -43,6 +45,7 @@ export default function useRefundRequestForm (props, context) {
       // convert to address format to component
       name.value = inputRefundRequestDetails.value?.name
       address.value = inputRefundRequestDetails.value?.mailingAddress
+      chequeAdvice.value = inputRefundRequestDetails.value?.chequeAdvice
     }
   }, { deep: true, immediate: true })
 
@@ -50,7 +53,9 @@ export default function useRefundRequestForm (props, context) {
     baseAddressSchema,
     refundRequestForm,
     nameRules,
+    chequeAdviceRules,
     name,
+    chequeAdvice,
     address,
     addressForm,
     addressValidity,

--- a/src/models/RoutingSlip.ts
+++ b/src/models/RoutingSlip.ts
@@ -10,6 +10,20 @@ export interface AccountInfo {
   billable?: boolean
   paymentMethod?: string
 }
+
+export interface RefundRequestDetails {
+  name?: string,
+  mailingAddress?: Address
+  chequeAdvice?: string
+}
+
+export interface Refund {
+  details?: RefundRequestDetails
+  id?: number
+  reason?: string
+  requestedBy?: string
+  requestedDate?: string
+}
 // Class for storing values in CreateRoutingSlip component - for POST endpoint
 export interface RoutingSlip {
   id?: number
@@ -24,7 +38,8 @@ export interface RoutingSlip {
   invoices?: Invoice[]
   status?: string
   createdName?:string,
-  parentNumber?:string
+  parentNumber?:string,
+  refunds?:Refund[]
 }
 // Class for storing values in CreateRoutingSlipDetails component
 export interface RoutingSlipDetails {
@@ -56,9 +71,4 @@ export interface ManualTransactionDetails{
 export interface GetRoutingSlipRequestPayload {
   routingSlipNumber: string,
   showGlobalLoader?: boolean
-}
-
-export interface RefundRequestDetails {
-  name?: string,
-  mailingAddress?: Address
 }

--- a/src/util/common-util.ts
+++ b/src/util/common-util.ts
@@ -3,10 +3,11 @@
  */
 
 import { Address, BaseAddressModel } from '@/models/Address'
-
 import { Role, SlipStatus } from '@/util/constants'
-import moment from 'moment'
+
 import KeyCloakService from 'sbc-common-components/src/services/keycloak.services'
+import moment from 'moment'
+
 export default class CommonUtils {
   // Formatting date in the desired format for displaying in the template
   static formatDisplayDate (date: Date, format?: string) {
@@ -15,6 +16,10 @@ export default class CommonUtils {
 
   static requiredFieldRule (errorMessage: string = 'This field is required') {
     return [v => !!v || errorMessage]
+  }
+
+  static optionalFieldRule (errorMessage: string, length: number) {
+    return [v => !v || (v.length <= length) || errorMessage]
   }
 
   static isSigningIn (): boolean {


### PR DESCRIPTION
*Issue #:* /bcgov/entity/9927

*Description of changes:*

- Refactor Refund request form to add UI for cheque advice field
- Send cheque advice details to pay-api refund object and retrieve as well


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
