### PR TITLE
10492 - Replace with balance field in routing slip search dashboard

### DIFF
--- a/src/components/Dashboard/Search.vue
+++ b/src/components/Dashboard/Search.vue
@@ -190,14 +190,14 @@
                             hide-details="auto"
                           />
                         </th>
-                        <th scope="total" v-if="canShowColumn('total')">
+                        <th scope="remainingAmount" v-if="canShowColumn('remainingAmount')">
                           <v-text-field
-                            id="total"
+                            id="remainingAmount"
                             autocomplete="off"
                             class="text-input-style "
                             filled
-                            placeholder="Total Amount"
-                            v-model.trim="totalAmount"
+                            placeholder="Balance"
+                            v-model.trim="remainingAmount"
                             @input="debouncedSearch()"
                             hide-details="auto"
                           />
@@ -361,11 +361,11 @@
                           </template>
                           <template v-else>-</template>
                         </td>
-                        <td v-if="canShowColumn('total')" class="text-right">
+                        <td v-if="canShowColumn('remainingAmount')" class="text-right">
                           <span class="font-weight-bold text-end">
                             {{
-                              item.total
-                                ? appendCurrencySymbol(item.total.toFixed(2))
+                              item.remainingAmount
+                                ? appendCurrencySymbol(item.remainingAmount.toFixed(2))
                                 : '-'
                             }}
                           </span>
@@ -416,7 +416,7 @@ import { PaymentMethods } from '@/util/constants'
       dateFilter,
       folioNumber,
       entityNumber,
-      totalAmount,
+      remainingAmount,
       chequeReceiptNumber,
       searchRoutingSlipResult,
       applyDateFilter,
@@ -444,7 +444,7 @@ import { PaymentMethods } from '@/util/constants'
       dateFilter,
       folioNumber,
       entityNumber,
-      totalAmount,
+      remainingAmount,
       chequeReceiptNumber,
       searchRoutingSlipResult,
       applyDateFilter,

--- a/src/composables/Dashboard/useSearch.ts
+++ b/src/composables/Dashboard/useSearch.ts
@@ -90,12 +90,12 @@ export function useSearch (props, context) {
       className: 'cheque-receipt-number'
     },
     {
-      text: 'Total Amount',
+      text: 'Balance',
       align: 'right',
-      value: 'total',
+      value: 'remainingAmount',
       sortable: false,
       display: true,
-      className: 'total'
+      className: 'remainingAmount'
     },
     {
       text: 'Actions',
@@ -196,14 +196,14 @@ export function useSearch (props, context) {
     }
   })
 
-  const totalAmount: any = computed({
+  const remainingAmount: any = computed({
     get: () => {
-      return searchRoutingSlipParams.value.totalAmount || ''
+      return searchRoutingSlipParams.value.remainingAmount || ''
     },
     set: (modalValue: any) => {
       setSearchRoutingSlipParams({
         ...searchRoutingSlipParams.value,
-        totalAmount: modalValue
+        remainingAmount: modalValue
       })
       searchParamsChanged.value = true
     }
@@ -331,7 +331,7 @@ export function useSearch (props, context) {
     dateFilter,
     folioNumber,
     entityNumber,
-    totalAmount,
+    remainingAmount,
     chequeReceiptNumber,
     canShowColumn,
     applyDateFilter,

--- a/tests/unit/components/Dashboard/search.spec.ts
+++ b/tests/unit/components/Dashboard/search.spec.ts
@@ -98,6 +98,6 @@ describe('Search.vue', () => {
     expect(wrapper.vm.canShowColumn('folioNumber')).toBeTruthy()
     expect(wrapper.vm.canShowColumn('entityNumber')).toBeTruthy()
     expect(wrapper.vm.canShowColumn('chequeReceiptNumber')).toBeTruthy()
-    expect(wrapper.vm.canShowColumn('total')).toBeTruthy()
+    expect(wrapper.vm.canShowColumn('remainingAmount')).toBeTruthy()
   })
 })

--- a/tests/unit/test-data/mock-search-headers.ts
+++ b/tests/unit/test-data/mock-search-headers.ts
@@ -55,12 +55,12 @@ export const headerSearch = [
     className: 'cheque-receipt-number'
   },
   {
-    text: 'Total Amount',
+    text: 'Balance',
     align: 'right',
-    value: 'total',
+    value: 'remainingAmount',
     sortable: false,
     display: true,
-    className: 'total'
+    className: 'remainingAmount'
   },
   {
     text: 'Actions',
@@ -130,12 +130,12 @@ export const updatedHeaderSearch = [
     className: 'cheque-receipt-number'
   },
   {
-    text: 'Total Amount',
+    text: 'Balance',
     align: 'right',
-    value: 'total',
+    value: 'remainingAmount',
     sortable: false,
     display: true,
-    className: 'total'
+    className: 'remainingAmount'
   },
   {
     text: 'Actions',


### PR DESCRIPTION
*Issue #:* /bcgov/entity/10492

*Description of changes:*

- Update FAS Dashboard search with balance rather than total amount


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
