### PR TITLE
Set default create routing slip date to today.

### DIFF
--- a/src/components/RoutingSlip/CreateRoutingSlipDetails.vue
+++ b/src/components/RoutingSlip/CreateRoutingSlipDetails.vue
@@ -46,6 +46,7 @@
 import { Component, Vue } from 'vue-property-decorator'
 import DatePicker from '@/components/common/DatePicker.vue'
 import { useCreateRoutingSlipDetails } from '@/composables/RoutingSlip'
+import moment from 'moment'
 
 @Component({
   components: {
@@ -66,6 +67,9 @@ import { useCreateRoutingSlipDetails } from '@/composables/RoutingSlip'
       isUniqueNumber,
       errorMessage
     } = useCreateRoutingSlipDetails()
+
+    routingSlipDate.value = routingSlipDate.value || moment().format('YYYY-MM-DD')
+
     return {
       createRoutingSlipDetailsForm,
       number,

--- a/src/composables/RoutingSlip/useCreateRoutingSlipDetails.ts
+++ b/src/composables/RoutingSlip/useCreateRoutingSlipDetails.ts
@@ -36,7 +36,7 @@ export function useCreateRoutingSlipDetails () {
     get: () => {
       return routingSlipDetails.value?.routingSlipDate || ''
     },
-    set: (modalValue: Date) => {
+    set: (modalValue: string) => {
       setRoutingSlipDetails({
         ...routingSlipDetails.value,
         routingSlipDate: modalValue


### PR DESCRIPTION
*Issue #:* /bcgov/entity/11183

Set RS Date field to default to the current day. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
