### PR TITLE
12050 - FAS - Ensure 2 decimal places when displaying amounts and on amount inputs

### DIFF
--- a/src/components/ReviewRoutingSlip/ReviewRoutingSlipCashPayment.vue
+++ b/src/components/ReviewRoutingSlip/ReviewRoutingSlipCashPayment.vue
@@ -19,7 +19,7 @@
       label="Amount(CAD$)"
       persistent-hint
       hide-details
-      :value="cashPayment.paidAmount"
+      :value="cashPayment.paidAmount.toFixed(2)"
       type="number"
       data-test="txt-paid-amount"
       >
@@ -32,7 +32,7 @@
       label="Amount(USD$)"
       persistent-hint
       hide-details
-      :value="cashPayment.paidUsdAmount"
+      :value="cashPayment.paidUsdAmount.toFixed(2)"
       type="number"
       data-test="txt-paid-amount"
       >

--- a/src/components/ReviewRoutingSlip/ReviewRoutingSlipChequePayment.vue
+++ b/src/components/ReviewRoutingSlip/ReviewRoutingSlipChequePayment.vue
@@ -32,7 +32,7 @@
         label="Amount(CAD$)"
         persistent-hint
         hide-details
-        :value="payment.paidAmount"
+        :value="payment.paidAmount.toFixed(2)"
         type="number"
         :data-test="getIndexedTag('txt-paid-amount', i)"
         >
@@ -45,7 +45,7 @@
         label="Amount(USD$)"
         persistent-hint
         hide-details
-        :value="payment.paidUsdAmount"
+        :value="payment.paidUsdAmount.toFixed(2)"
         type="number"
         :data-test="getIndexedTag('txt-paid-amount', i)"
         >

--- a/src/components/ReviewRoutingSlip/ReviewRoutingSlipPayment.vue
+++ b/src/components/ReviewRoutingSlip/ReviewRoutingSlipPayment.vue
@@ -16,7 +16,7 @@
       Total Amount
     </v-col>
     <v-col class="col-9" data-test="total">
-      {{ appendCurrencySymbol(totalAmount) }}
+      {{ appendCurrencySymbol(totalAmount.toFixed(2)) }}
     </v-col>
   </template>
   </v-row>

--- a/src/components/ViewRoutingSlip/AddManualTransactionDetails.vue
+++ b/src/components/ViewRoutingSlip/AddManualTransactionDetails.vue
@@ -43,7 +43,7 @@
         label="$ Amount"
         persistent-hint
         :data-test="getIndexedTag('txt-amount', index)"
-        v-model="manualTransactionDetails.total"
+        v-model="totalFormatted"
       >
       </v-text-field>
       <div class="close-icon">
@@ -105,7 +105,8 @@ import { ManualTransactionDetails } from '@/models/RoutingSlip'
       delayedCalculateTotal,
       getIndexedTag,
       emitManualTransactionDetails,
-      errorMessage
+      errorMessage,
+      totalFormatted
     } = useAddManualTransactionDetails(props, context)
     return {
       manualTransactionDetails,
@@ -115,7 +116,8 @@ import { ManualTransactionDetails } from '@/models/RoutingSlip'
       delayedCalculateTotal,
       getIndexedTag,
       emitManualTransactionDetails,
-      errorMessage
+      errorMessage,
+      totalFormatted
     }
   }
 })

--- a/src/composables/RoutingSlip/useCreateRoutingSlipCashPayment.ts
+++ b/src/composables/RoutingSlip/useCreateRoutingSlipCashPayment.ts
@@ -68,12 +68,18 @@ export function useCreateRoutingSlipCashPayment () {
 
   // Input field rules
   const receiptNumberRules = CommonUtils.requiredFieldRule('A Receipt number is required')
-  const paidUsdAmountRules = CommonUtils.requiredFieldRule('Paid Amount in USD is required')
+
+  const paidUsdAmountRules = [
+    v => !!v || 'Paid Amount in USD is required',
+    v => v && (/^\d+(\.\d{1,2})?$/.test(v) || 'Paid Amount in USD can only be up to 2 decimal places')
+  ]
+
   const paidAmountRules = [
     v => !!v || 'Paid Amount is required',
     v => {
       return v >= 0 || 'Valid Paid Amount is required'
-    }
+    },
+    v => (/^\d+(\.\d{1,2})?$/.test(v) || 'Paid Amount can only be up to 2 decimal places')
   ]
 
   const getColumnWidth = computed(() => {

--- a/src/composables/RoutingSlip/useCreateRoutingSlipChequePayment.ts
+++ b/src/composables/RoutingSlip/useCreateRoutingSlipChequePayment.ts
@@ -24,14 +24,19 @@ export function useCreateRoutingSlipChequePayment () {
 
   // Input field rules
   const chequeNumberRules = CommonUtils.requiredFieldRule('A Cheque number is required')
-  const paidUsdAmountRules = CommonUtils.requiredFieldRule('Paid Amount in USD is required')
   const paymentDateRules = CommonUtils.requiredFieldRule('Cheque date is required')
+
+  const paidUsdAmountRules = [
+    v => !!v || 'Paid Amount in USD is required',
+    v => v && (/^\d+(\.\d{1,2})?$/.test(v) || 'Paid Amount in USD can only be up to 2 decimal places')
+  ]
 
   const paidAmountRules = [
     v => !!v || 'Paid Amount is required',
     v => {
       return v >= 0 || 'Valid Paid Amount is required'
-    }
+    },
+    v => v && (/^\d+(\.\d{1,2})?$/.test(v) || 'Paid Amount can only be up to 2 decimal places')
   ]
 
   // Compute individual cheque paid amount to calculate total paid amount

--- a/src/composables/ViewRoutingSlip/useAddManualTransactionDetails.ts
+++ b/src/composables/ViewRoutingSlip/useAddManualTransactionDetails.ts
@@ -35,6 +35,10 @@ export default function useAddManualTransactionDetails (props, context) {
     return msg
   })
 
+  const totalFormatted = computed(() => {
+    return manualTransaction.value?.total?.toFixed(2)
+  })
+
   // Calculate total fee from pay-api service, triggered if its dependent values are changed
   async function calculateTotal () {
     try {
@@ -97,6 +101,7 @@ export default function useAddManualTransactionDetails (props, context) {
     calculateTotal,
     getIndexedTag,
     emitManualTransactionDetails,
-    errorMessage
+    errorMessage,
+    totalFormatted
   }
 }

--- a/tests/unit/components/ReviewRoutingSlip/reviewRoutingSlipCashPayment.spec.ts
+++ b/tests/unit/components/ReviewRoutingSlip/reviewRoutingSlipCashPayment.spec.ts
@@ -22,6 +22,6 @@ describe('ReviewRoutingSlipCashPayment.vue', () => {
     })
 
     expect(wrapper.find('[data-test="txt-receipt-number"]').element.value).toEqual(cashPayment.chequeReceiptNumber)
-    expect(wrapper.find('[data-test="txt-paid-amount"]').element.value).toEqual(cashPayment.paidAmount.toString())
+    expect(wrapper.find('[data-test="txt-paid-amount"]').element.value).toEqual(cashPayment.paidAmount.toFixed(2).toString())
   })
 })

--- a/tests/unit/components/ReviewRoutingSlip/reviewRoutingSlipChequePayment.spec.ts
+++ b/tests/unit/components/ReviewRoutingSlip/reviewRoutingSlipChequePayment.spec.ts
@@ -22,10 +22,10 @@ describe('ReviewRoutingSlipChequePayment.vue', () => {
 
     expect(wrapper.find('[data-test="txt-cheque-receipt-number-0"]').element.value).toEqual(chequePayment[0].chequeReceiptNumber)
     expect(wrapper.find('[data-test="txt-cheque-date-0"]').element.value).toEqual('-')
-    expect(wrapper.find('[data-test="txt-paid-amount-0"]').element.value).toEqual(chequePayment[0].paidAmount.toString())
+    expect(wrapper.find('[data-test="txt-paid-amount-0"]').element.value).toEqual(chequePayment[0].paidAmount.toFixed(2).toString())
 
     expect(wrapper.find('[data-test="txt-cheque-receipt-number-1"]').element.value).toEqual(chequePayment[1].chequeReceiptNumber)
     expect(wrapper.find('[data-test="txt-cheque-date-1"]').element.value).toEqual('-')
-    expect(wrapper.find('[data-test="txt-paid-amount-1"]').element.value).toEqual(chequePayment[1].paidAmount.toString())
+    expect(wrapper.find('[data-test="txt-paid-amount-1"]').element.value).toEqual(chequePayment[1].paidAmount.toFixed(2).toString())
   })
 })

--- a/tests/unit/components/ReviewRoutingSlip/reviewRoutingSlipPayment.spec.ts
+++ b/tests/unit/components/ReviewRoutingSlip/reviewRoutingSlipPayment.spec.ts
@@ -29,7 +29,7 @@ describe('ReviewRoutingSlipPayment.vue', () => {
     expect(wrapper.find('[data-test="payment-info"]').text()).toEqual('Cheque')
     expect(wrapper.find('[data-test="review-routing-slip-cheque-payment"]').exists()).toBeTruthy()
     expect(wrapper.find('[data-test="review-routing-slip-cash-payment"]').exists()).toBeFalsy()
-    expect(wrapper.find('[data-test="total"]').text()).toEqual('$200')
+    expect(wrapper.find('[data-test="total"]').text()).toEqual('$200.00')
   })
 
   it('validates component behaviour', async () => {


### PR DESCRIPTION
*Issue #:* /bcgov/entity#12050

*Description of changes:*
Change a few of the fields so they display 2 digits. 
Put in validation for money to ensure they don't include more than 2 digits. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
