### PR TITLE
14618 - make receipt number non-editable for cash routing slip correction

### DIFF
--- a/src/components/ReviewRoutingSlip/ReviewRoutingSlipCashPayment.vue
+++ b/src/components/ReviewRoutingSlip/ReviewRoutingSlipCashPayment.vue
@@ -3,13 +3,12 @@
     <v-col :cols="isAmountPaidInUsd ? 4: 6">
       <v-text-field
       filled
-      :disabled="!isEditable || isALinkedChild"
+      disabled
       label="Receipt Number"
       persistent-hint
       hide-details
       :value="cashPayment.chequeReceiptNumber"
       data-test="txt-receipt-number"
-      @input="e => adjustRoutingSlipChequeNumber(e)"
       >
       </v-text-field>
     </v-col>


### PR DESCRIPTION
*Issue [#14618:*](https://app.zenhub.com/workspaces/relationships-team-space-61435c47e483c4000f08e9f6/issues/gh/bcgov/entity/14618) /bcgov/entity###

*Description of changes:*
make receipt number non-editable for cash routing slip correction

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
