### PR TITLE
18311 - FAS-UI removing NSF from Manual Transactions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fas-ui",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "fas-ui",
-      "version": "1.1.3",
+      "version": "1.1.4",
       "dependencies": {
         "@bcrs-shared-components/enums": "1.0.13",
         "@bcrs-shared-components/interfaces": "1.0.23",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fas-ui",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "private": true,
   "main": "./lib/lib.umd.min.js",
   "files": [

--- a/src/composables/ViewRoutingSlip/useFilingTypeAutoComplete.ts
+++ b/src/composables/ViewRoutingSlip/useFilingTypeAutoComplete.ts
@@ -31,7 +31,7 @@ export default function useFilingTypeAutoComplete (props, context) {
       if (search.value.length > 2) {
         const response = await RoutingSlipService.getSearchFilingType(search.value)
         if (response && response.data && response.status === 200) {
-          autoCompleteFilingTypes.value = response.data?.items
+          autoCompleteFilingTypes.value = response.data?.items.filter(item => item?.filingTypeCode?.code !== 'NSF')
         } else {
           autoCompleteFilingTypes.value = []
         }


### PR DESCRIPTION
*Issue #:* [/bcgov/entity#18311](https://github.com/bcgov/entity/issues/18311)

*Description of changes:*
- Updated useFilingTypeAutoComplete.ts to not display NSF in Manual Transaction types

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
