### PR TITLE
24500 - Reset routing slip address on new form

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fas-ui",
-  "version": "1.2.18",
+  "version": "1.2.19",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "fas-ui",
-      "version": "1.2.18",
+      "version": "1.2.19",
       "dependencies": {
         "@bcrs-shared-components/base-address": "^2.0.3",
         "@bcrs-shared-components/enums": "^1.0.51",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fas-ui",
-  "version": "1.2.18",
+  "version": "1.2.19",
   "private": true,
   "main": "./lib/lib.umd.min.js",
   "appName": "FAS UI",

--- a/src/composables/useRoutingSlip.ts
+++ b/src/composables/useRoutingSlip.ts
@@ -234,6 +234,7 @@ export const useRoutingSlip = () => {
     chequePayment.value = undefined
     cashPayment.value = undefined
     isPaymentMethodCheque.value = undefined
+    routingSlipAddress.value = undefined
   }
 
   const resetSearchParams = (): void => {


### PR DESCRIPTION
*Issue #:* /bcgov/entity/24500 

*Description of changes:*
The routing slip address form fields now reset when starting a new form.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
