### PR TITLE
chore: upgrade to Node.js 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
   pay-ui-ci:
     uses: bcgov/bcregistry-sre/.github/workflows/frontend-ci.yaml@main
     with:
-      node_version: "20.5.1"
+      node_version: "24"
       app_name: "pay-ui"
       working_directory: "."
       codecov_flag: "payweb"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20.5.1 as build-stage
+FROM node:24 as build-stage
 WORKDIR /app
 COPY ./package*.json ./
 RUN npm install

--- a/devops/cloudbuild-pr.yaml
+++ b/devops/cloudbuild-pr.yaml
@@ -1,6 +1,6 @@
 steps:
   # install / setup ci
-  - name: node:20.5.1
+  - name: node:24
     entrypoint: npm
     dir: "."
     args: ['install']
@@ -15,7 +15,7 @@ steps:
   #
   # Generate the static site
   #
-  - name: node:20.5.1
+  - name: node:24
     dir: "."
     entrypoint: npm
     env:

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "npm": "^7.19.0",
     "pinia": "^2.1.7",
     "postcss-nesting": "^12.0.1",
-    "sbc-common-components": "^3.1.6",    
+    "sbc-common-components": "^3.1.6",
     "vite": "^4.5.10",
     "vite-plugin-environment": "^1.1.3",
     "vite-plugin-rewrite-all": "^1.0.1",
@@ -84,5 +84,8 @@
   "peerDependencies": {
     "@vue/composition-api": "^1.7.1",
     "vue": "^2.6.11"
+  },
+  "engines": {
+    "node": ">=24"
   }
 }


### PR DESCRIPTION
*Issue:* https://app.zenhub.com/workspaces/sre-team-board-654d163c6817d80016102d9a/issues/gh/bcgov/entity/32835 

- bcgov/entity/issues/

*Description of changes:*
Update engines field in package.json to require Node.js >= 24.
Update node_version from 20 to 24

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License
