### PR TITLE
33704 - UX Transaction receipt download indicator

### DIFF
--- a/web/pay-ui/app/assets/scss/search-table.scss
+++ b/web/pay-ui/app/assets/scss/search-table.scss
@@ -116,7 +116,7 @@
 }
 
 .table-scroll,
-.table-scroll * {
+.table-scroll *:not(.animate-spin) {
   transform: none !important;
   will-change: auto !important;
 }

--- a/web/pay-ui/app/components/transactions/TransactionsDataTable.vue
+++ b/web/pay-ui/app/components/transactions/TransactionsDataTable.vue
@@ -29,10 +29,6 @@ const props = withDefaults(defineProps<Props>(), {
   extended: false
 })
 
-const emit = defineEmits<{
-  isDownloadingReceipt: [value: boolean]
-}>()
-
 const {
   searchTransactionsTableHeaders,
   columnPinning,
@@ -63,6 +59,7 @@ const {
 setViewAll(props.extended)
 
 const expandedRows = ref(new Set<number>())
+const downloadingReceiptIds = ref(new Set<number>())
 
 type TableRow = Transaction | DropdownItem
 
@@ -450,7 +447,7 @@ function initiateRefund(item: Transaction) {
 }
 
 async function downloadReceipt(item: Transaction) {
-  emit('isDownloadingReceipt', true)
+  downloadingReceiptIds.value.add(item.id)
   try {
     const nuxtApp = useNuxtApp()
     const $payApi = nuxtApp.$payApi as typeof nuxtApp.$payApi
@@ -473,7 +470,7 @@ async function downloadReceipt(item: Transaction) {
   } catch (error) {
     console.error('Failed to download receipt', error)
   } finally {
-    emit('isDownloadingReceipt', false)
+    downloadingReceiptIds.value.delete(item.id)
   }
 }
 
@@ -996,10 +993,16 @@ watch(() => transactions.results, () => {
             <span
               v-else
               class="receipt-link"
+              :class="{ 'pointer-events-none opacity-60': downloadingReceiptIds.has(asTransaction(row).id) }"
               @click="downloadReceipt(asTransaction(row))"
             >
-              <UIcon name="i-mdi-file-download-outline" />
-              Receipt
+              <template v-if="downloadingReceiptIds.has(asTransaction(row).id)">
+                <UIcon name="i-mdi-loading" class="size-5 animate-spin" />
+              </template>
+              <template v-else>
+                <UIcon name="i-mdi-file-download-outline" class="size-5" />
+                <span>Receipt</span>
+              </template>
             </span>
           </template>
 

--- a/web/pay-ui/app/pages/transaction-view/[id]/TransactionDetails.vue
+++ b/web/pay-ui/app/pages/transaction-view/[id]/TransactionDetails.vue
@@ -21,6 +21,9 @@ async function handleDownloadReceipt() {
   try {
     await downloadReceipt(props.transactionData)
   }
+  catch (error) {
+    console.error('Failed to download receipt', error)
+  }
   finally {
     isDownloadingReceipt.value = false
   }
@@ -49,6 +52,7 @@ async function handleDownloadReceipt() {
         <div class="sm:col-span-3">
           <button
             v-if="canDownloadReceipt"
+            data-testid="receipt-download-btn"
             class="flex items-center gap-1 text-primary cursor-pointer hover:underline
             disabled:opacity-60 disabled:cursor-not-allowed"
             :disabled="isDownloadingReceipt"

--- a/web/pay-ui/package.json
+++ b/web/pay-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pay-ui",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "type": "module",
   "private": true,
   "scripts": {

--- a/web/pay-ui/tests/unit/components/TransactionView/TransactionDetails.spec.ts
+++ b/web/pay-ui/tests/unit/components/TransactionView/TransactionDetails.spec.ts
@@ -1,4 +1,5 @@
-import { mount } from '@vue/test-utils'
+import { mount, flushPromises } from '@vue/test-utils'
+import { nextTick } from 'vue'
 import TransactionDetails from '~/pages/transaction-view/[id]/TransactionDetails.vue'
 import type { TransactionData } from '~/interfaces/transaction-view'
 import { InvoiceStatus } from '~/utils/constants'
@@ -47,7 +48,7 @@ describe('TransactionDetails', () => {
       global: {
         stubs: {
           NuxtLink: { template: '<a><slot /></a>' },
-          UIcon: true
+          UIcon: { props: ['name'], template: '<span :data-icon-name="name" />' }
         }
       }
     })
@@ -71,12 +72,59 @@ describe('TransactionDetails', () => {
     expect(wrapper.text()).toContain('NR_NUMBER')
   })
 
+  it('should not show receipt button when invoice is not PAID or COMPLETED', () => {
+    const wrapper = createWrapper({ invoiceStatusCode: InvoiceStatus.CREATED })
+    expect(wrapper.find('[data-testid="receipt-download-btn"]').exists()).toBe(false)
+  })
+
   it('should call downloadReceipt when receipt button is clicked', async () => {
     const wrapper = createWrapper({ invoiceStatusCode: InvoiceStatus.PAID })
-    await wrapper.find('button').trigger('click')
+    await wrapper.find('[data-testid="receipt-download-btn"]').trigger('click')
     expect(mockDownloadReceipt).toHaveBeenCalledWith(
       expect.objectContaining({ invoiceId: sampleData.invoiceId })
     )
+  })
+
+  it('should show spinner and disable button while downloading', async () => {
+    let resolveDownload!: () => void
+    mockDownloadReceipt.mockReturnValue(
+      new Promise<void>((resolve) => { resolveDownload = resolve })
+    )
+
+    const wrapper = createWrapper({ invoiceStatusCode: InvoiceStatus.PAID })
+    const btn = wrapper.find('[data-testid="receipt-download-btn"]')
+
+    expect(btn.find('[data-icon-name="i-mdi-file-pdf-outline"]').exists()).toBe(true)
+    expect(btn.find('[data-icon-name="i-mdi-loading"]').exists()).toBe(false)
+    expect(btn.attributes('disabled')).toBeUndefined()
+
+    await btn.trigger('click')
+    await nextTick()
+
+    expect(btn.attributes('disabled')).toBeDefined()
+    expect(btn.find('[data-icon-name="i-mdi-loading"]').exists()).toBe(true)
+    expect(btn.find('[data-icon-name="i-mdi-file-pdf-outline"]').exists()).toBe(false)
+
+    resolveDownload()
+    await flushPromises()
+
+    expect(btn.attributes('disabled')).toBeUndefined()
+    expect(btn.find('[data-icon-name="i-mdi-file-pdf-outline"]').exists()).toBe(true)
+    expect(btn.find('[data-icon-name="i-mdi-loading"]').exists()).toBe(false)
+  })
+
+  it('should restore button to normal state if download throws', async () => {
+    mockDownloadReceipt.mockRejectedValue(new Error('network error'))
+
+    const wrapper = createWrapper({ invoiceStatusCode: InvoiceStatus.PAID })
+    const btn = wrapper.find('[data-testid="receipt-download-btn"]')
+
+    await btn.trigger('click')
+    await flushPromises()
+
+    expect(btn.attributes('disabled')).toBeUndefined()
+    expect(btn.find('[data-icon-name="i-mdi-file-pdf-outline"]').exists()).toBe(true)
+    expect(btn.find('[data-icon-name="i-mdi-loading"]').exists()).toBe(false)
   })
 
   it('should show routing slip column when present', () => {


### PR DESCRIPTION
*Issue #:* https://github.com/bcgov/entity/issues/33704

*Description of changes:*
- add receipt download spinner for transaction search rows

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the pay-ui license (Apache 2.0).
