### PR TITLE
chore: upgrade packageManager to pnpm@11.9.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     uses: bcgov/bcregistry-sre/.github/workflows/frontend-ci.yaml@main
     with:
       node_version: 24
-      pnpm_version: 10.0.0
+      pnpm_version: latest-11
       app_name: "pay-ui"
       working_directory: "./web/pay-ui"
       codecov_flag: "payweb"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     uses: bcgov/bcregistry-sre/.github/workflows/frontend-ci.yaml@main
     with:
       node_version: 24
-      pnpm_version: latest-11
+      pnpm_version: 11.9.0
       app_name: "pay-ui"
       working_directory: "./web/pay-ui"
       codecov_flag: "payweb"

--- a/.github/workflows/test-pnpm-v11.yml
+++ b/.github/workflows/test-pnpm-v11.yml
@@ -1,0 +1,38 @@
+name: Test pnpm v11 upgrade
+on:
+  push:
+    branches: [feat/upgrade-pnpm-v11]
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/workflows/test-pnpm-v11.yml'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+
+jobs:
+  test-pnpm-v11:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: web/pay-ui
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v6
+        with:
+          version: latest-11
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+          cache-dependency-path: web/pay-ui/pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build
+        run: pnpm build
+
+      - name: Report pnpm version
+        run: pnpm --version

--- a/.github/workflows/test-pnpm-v11.yml
+++ b/.github/workflows/test-pnpm-v11.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: pnpm/action-setup@v6
         with:
-          version: latest-11
+          version: 11.9.0
 
       - uses: actions/setup-node@v6
         with:
@@ -29,7 +29,10 @@ jobs:
           cache-dependency-path: web/pay-ui/pnpm-lock.yaml
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --ignore-scripts
+
+      - name: Nuxt Prepare
+        run: pnpm exec nuxt prepare
 
       - name: Build
         run: pnpm build

--- a/web/pay-ui/package.json
+++ b/web/pay-ui/package.json
@@ -52,5 +52,5 @@
     "vitest": "^3.2.3",
     "vue-tsc": "^3.0.4"
   },
-  "packageManager": "pnpm@10.17.1+sha512.17c560fca4867ae9473a3899ad84a88334914f379be46d455cbf92e5cf4b39d34985d452d2583baf19967fa76cb5c17bc9e245529d0b98745721aa7200ecaf7a"
+  "packageManager": "pnpm@11.9.0"
 }

--- a/web/pay-ui/package.json
+++ b/web/pay-ui/package.json
@@ -52,5 +52,5 @@
     "vitest": "^3.2.3",
     "vue-tsc": "^3.0.4"
   },
-  "packageManager": "pnpm@11.9.0"
+  "packageManager": "pnpm@11.9.0+sha512.bd682d5d03fe525ef7c9fd6780c6884d1e756ac4c9c9fe00c538782824310dcf90e3ddc4f53835f06dfaebd5085e41855e0bcbb3b60de2ac5bbab89e5036f03b"
 }


### PR DESCRIPTION
Sets `packageManager` to `pnpm@11.9.0` in `web/pay-ui/package.json` as part of the pnpm v11 upgrade (ticket #33875).

The CI/CD Cloud Build trigger for this app has already been updated to use `pnpm@11.9.0`.