### PR TITLE
[TEST] pnpm v11 upgrade - CI validation

### DIFF
--- a/.github/workflows/test-pnpm-v11.yml
+++ b/.github/workflows/test-pnpm-v11.yml
@@ -20,6 +20,9 @@ jobs:
           cache-dependency-path: web/pay-ui/pnpm-lock.yaml
       - name: Install (from workspace root)
         run: pnpm install --no-frozen-lockfile --ignore-scripts
+      - name: Prepare (generate .nuxt types)
+        working-directory: web/pay-ui
+        run: pnpm nuxt prepare
       - name: Build
         working-directory: web/pay-ui
         run: pnpm build

--- a/.github/workflows/test-pnpm-v11.yml
+++ b/.github/workflows/test-pnpm-v11.yml
@@ -7,9 +7,6 @@ on:
 jobs:
   test-pnpm-v11:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: web/pay-ui
     steps:
       - uses: actions/checkout@v6
       - name: Setup pnpm v11
@@ -21,9 +18,10 @@ jobs:
           node-version: 24
           cache: pnpm
           cache-dependency-path: web/pay-ui/pnpm-lock.yaml
-      - name: Install
-        run: pnpm install
+      - name: Install (from workspace root)
+        run: pnpm install --no-frozen-lockfile --ignore-scripts
       - name: Build
+        working-directory: web/pay-ui
         run: pnpm build
       - name: Verify pnpm version
         run: pnpm --version

--- a/.github/workflows/test-pnpm-v11.yml
+++ b/.github/workflows/test-pnpm-v11.yml
@@ -1,0 +1,29 @@
+name: "[TEST] pnpm v11 upgrade"
+on:
+  push:
+    branches: ["test/pnpm-v11-upgrade"]
+  workflow_dispatch:
+
+jobs:
+  test-pnpm-v11:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: web/pay-ui
+    steps:
+      - uses: actions/checkout@v6
+      - name: Setup pnpm v11
+        uses: pnpm/action-setup@v6
+        with:
+          version: latest-11
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+          cache-dependency-path: web/pay-ui/pnpm-lock.yaml
+      - name: Install
+        run: pnpm install
+      - name: Build
+        run: pnpm build
+      - name: Verify pnpm version
+        run: pnpm --version

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,11 @@
+# This file is at the repo root so pnpm v11 reads onlyBuiltDependencies
+# for the web/pay-ui app. pnpm-workspace.yaml must be at git root.
+onlyBuiltDependencies:
+  - "@parcel/watcher"
+  - "@sbc-connect/nuxt-auth"
+  - "@sbc-connect/nuxt-base"
+  - "@sbc-connect/nuxt-forms"
+  - "@sbc-connect/nuxt-pay"
+  - "@tailwindcss/oxide"
+  - esbuild
+  - vue-demi

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,6 @@
-# This file is at the repo root so pnpm v11 reads onlyBuiltDependencies
-# for the web/pay-ui app. pnpm-workspace.yaml must be at git root.
+packages:
+  - web/pay-ui
+
 onlyBuiltDependencies:
   - "@parcel/watcher"
   - "@sbc-connect/nuxt-auth"

--- a/web/pay-ui/package.json
+++ b/web/pay-ui/package.json
@@ -52,5 +52,5 @@
     "vitest": "^3.2.3",
     "vue-tsc": "^3.0.4"
   },
-  "packageManager": "pnpm@10.17.1+sha512.17c560fca4867ae9473a3899ad84a88334914f379be46d455cbf92e5cf4b39d34985d452d2583baf19967fa76cb5c17bc9e245529d0b98745721aa7200ecaf7a"
+  "packageManager": "pnpm@11.9.0"
 }

--- a/web/pay-ui/pnpm-workspace.yaml
+++ b/web/pay-ui/pnpm-workspace.yaml
@@ -1,0 +1,9 @@
+onlyBuiltDependencies:
+  - "@parcel/watcher"
+  - "@sbc-connect/nuxt-auth"
+  - "@sbc-connect/nuxt-base"
+  - "@sbc-connect/nuxt-forms"
+  - "@sbc-connect/nuxt-pay"
+  - "@tailwindcss/oxide"
+  - esbuild
+  - vue-demi

--- a/web/pay-ui/pnpm-workspace.yaml
+++ b/web/pay-ui/pnpm-workspace.yaml
@@ -1,9 +1,0 @@
-onlyBuiltDependencies:
-  - "@parcel/watcher"
-  - "@sbc-connect/nuxt-auth"
-  - "@sbc-connect/nuxt-base"
-  - "@sbc-connect/nuxt-forms"
-  - "@sbc-connect/nuxt-pay"
-  - "@tailwindcss/oxide"
-  - esbuild
-  - vue-demi


### PR DESCRIPTION
## Test PR — do not merge

This PR exists solely to trigger CI and validate that pnpm v11 is compatible.

- Runs `test-pnpm-v11.yml` (or `test-pnpm-v11-ci.yml`) which uses `pnpm@latest-11`
- Does **not** modify any existing CI workflows
- Will be closed once CI passes and the real upgrade PRs are merged

> Ticket: #33875