### PR TITLE
fix: add allowBuilds for build scripts blocked under pnpm v11

### DIFF
--- a/web/pay-ui/pnpm-workspace.yaml
+++ b/web/pay-ui/pnpm-workspace.yaml
@@ -1,0 +1,10 @@
+packages: []
+allowBuilds:
+  '@parcel/watcher': true
+  '@sbc-connect/nuxt-auth': true
+  '@sbc-connect/nuxt-base': true
+  '@sbc-connect/nuxt-forms': true
+  '@sbc-connect/nuxt-pay': true
+  '@tailwindcss/oxide': true
+  esbuild: true
+  vue-demi: true


### PR DESCRIPTION
## Summary
pay-ui had no `pnpm-workspace.yaml` anywhere in the repo. This was invisible in PR CI, which installs with `--ignore-scripts` (the shared `frontend-ci.yaml`) and so never needs build-script approval at all. But the deploy pipeline's Cloud Build config installs without that flag, and pnpm v11 correctly refuses to run any package's install/postinstall scripts without explicit approval.

Confirmed via a real deploy attempt (`dev` target, 2026-08-03, once the pnpm-version issues in bcgov/bcregistry-sre#377/#378/#379 were fixed) which failed with:
```
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: @parcel/watcher@2.5.1,
@sbc-connect/nuxt-auth@0.1.23, @sbc-connect/nuxt-base@0.1.21,
@sbc-connect/nuxt-forms@0.1.23, @sbc-connect/nuxt-pay@0.1.23,
@tailwindcss/oxide@4.1.13, esbuild@0.25.10, vue-demi@0.14.10
```

## Fix
Added `web/pay-ui/pnpm-workspace.yaml` approving exactly those packages, matching the `allowBuilds` pattern already used in every other repo in the pnpm-v11 migration.

## Test plan
- [ ] Trigger a `dev`-target redeploy once merged and confirm the build proceeds past the install step