### PR TITLE
34476  - Fix routing slip date showing one day earlier

### DIFF
--- a/web/pay-ui/app/composables/viewRoutingSlip/useRoutingSlipInfo.ts
+++ b/web/pay-ui/app/composables/viewRoutingSlip/useRoutingSlipInfo.ts
@@ -5,7 +5,6 @@ import { SlipStatusDropdown, ChequeRefundStatus, chequeRefundCodes } from '~/uti
 import commonUtil from '~/utils/common-util'
 import type { Address } from '~/interfaces/address'
 import type { RefundRequestDetails } from '~/interfaces/routing-slip'
-import { DateTime } from 'luxon'
 
 export function useRoutingSlipInfo() {
   const { updateRoutingSlipStatus, updateRoutingSlipRefundStatus,
@@ -35,12 +34,11 @@ export function useRoutingSlipInfo() {
 
   const state = reactive({
     formattedDate: computed<string>(() => {
-      const date = store.routingSlip.createdOn
+      const date = store.routingSlip.routingSlipDate
       if (!date) {
         return '-'
       }
-      const dt = DateTime.fromISO(date, { zone: 'UTC' }).setZone('America/Vancouver')
-      return dt.isValid ? dt.toFormat('MMM dd, yyyy') : '-'
+      return commonUtil.formatDisplayDate(date, 'MMM dd, yyyy') || '-'
     }),
     statusColor: computed<string>(() => {
       const status = store.routingSlip.status

--- a/web/pay-ui/app/utils/common-util.ts
+++ b/web/pay-ui/app/utils/common-util.ts
@@ -1,6 +1,8 @@
 import type { Address } from '~/interfaces/address'
 import { DateTime } from 'luxon'
 
+const DATE_ONLY_PATTERN = /^\d{4}-\d{2}-\d{2}$/
+
 function formatDisplayDate(
   date: Date | string | null | undefined,
   format: string | 'start' | 'end' = 'MMM dd, yyyy'
@@ -14,8 +16,13 @@ function formatDisplayDate(
     date = date.replace(' ', 'T')
   }
 
+  // Date only values (eg. routing slip date) have no time or timezone - reading them as a
+  // UTC instant would push them into the previous day once shifted to Pacific time, so parse
+  // them in Pacific time to keep the calendar date as stored.
+  const zone = typeof date === 'string' && DATE_ONLY_PATTERN.test(date) ? 'America/Vancouver' : 'utc'
+
   const dateTime = typeof date === 'string'
-    ? DateTime.fromISO(date, { zone: 'utc' }).setZone('America/Vancouver')
+    ? DateTime.fromISO(date, { zone }).setZone('America/Vancouver')
     : DateTime.fromJSDate(date, { zone: 'utc' }).setZone('America/Vancouver')
 
   if (!dateTime.isValid) {

--- a/web/pay-ui/package.json
+++ b/web/pay-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pay-ui",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "type": "module",
   "private": true,
   "scripts": {

--- a/web/pay-ui/tests/unit/composables/dashboard/useSearch.spec.ts
+++ b/web/pay-ui/tests/unit/composables/dashboard/useSearch.spec.ts
@@ -3,7 +3,7 @@ import { useSearch } from '~/composables/dashboard/useSearch'
 import { chequeRefundCodes } from '~/utils/constants'
 import { createPinia, setActivePinia } from 'pinia'
 import { nextTick } from 'vue'
-import type { RoutingSlipDetails } from '~/interfaces/routing-slip'
+import type { RoutingSlip, RoutingSlipDetails } from '~/interfaces/routing-slip'
 import type { Invoice } from '~/interfaces/invoice'
 
 const mockPostSearchRoutingSlip = vi.fn()
@@ -129,20 +129,21 @@ describe('useSearch', () => {
   it('should compute routingSlips from searchRoutingSlipResult', async () => {
     const composable = await useSearch()
     const { store } = useRoutingSlipStore()
-    store.searchRoutingSlipResult = [
-      {
-        number: '123',
-        status: 'ACTIVE',
-        routingSlipDate: '2025-09-26',
-        invoices: [],
-        paymentAccount: null,
-        payments: []
-      }
-    ] as Partial<Invoice>[]
+    store.searchRoutingSlipResult.length = 0
+    store.searchRoutingSlipResult.push({
+      number: '123',
+      status: 'ACTIVE',
+      routingSlipDate: '2025-09-26',
+      invoices: [],
+      paymentAccount: null,
+      payments: []
+    } as unknown as RoutingSlip)
 
     await nextTick()
     expect(composable.routingSlips.value).toBeDefined()
     expect(Array.isArray(composable.routingSlips.value)).toBe(true)
+    // the routing slip date is a date only value - it must display as stored
+    expect(composable.routingSlips.value[0]?.date).toBe('September 26, 2025')
   })
 
   it('should compute columnVisibility from table headers', async () => {

--- a/web/pay-ui/tests/unit/composables/viewRoutingSlip/useRoutingSlipInfo.spec.ts
+++ b/web/pay-ui/tests/unit/composables/viewRoutingSlip/useRoutingSlipInfo.spec.ts
@@ -89,6 +89,7 @@ const mockStore: {
     number: string
     status: string | null
     createdOn: string | null
+    routingSlipDate: string | null
     paymentAccount: { accountName: string } | null
     contactName: string
     mailingAddress: {
@@ -110,6 +111,7 @@ const mockStore: {
     number: '123456',
     status: 'ACTIVE',
     createdOn: '2025-01-01T00:00:00Z',
+    routingSlipDate: '2025-01-01',
     paymentAccount: {
       accountName: 'Test Account'
     },
@@ -137,6 +139,7 @@ describe('useRoutingSlipInfo', () => {
       number: '123456',
       status: 'ACTIVE',
       createdOn: '2025-01-01T00:00:00Z',
+      routingSlipDate: '2025-01-01',
       paymentAccount: {
         accountName: 'Test Account'
       },
@@ -185,7 +188,7 @@ describe('useRoutingSlipInfo', () => {
 
   it('should return basic computed properties and handle all status select scenarios', async () => {
     const composable = useRoutingSlipInfo()
-    expect(composable.formattedDate.value).toBe('Dec 31, 2024')
+    expect(composable.formattedDate.value).toBe('Jan 01, 2025')
     expect(composable.statusLabel.value).toBeDefined()
     expect(composable.entityNumber.value).toBe('Test Account')
     expect(composable.contactName.value).toBe('Test Contact')
@@ -527,11 +530,11 @@ describe('useRoutingSlipInfo', () => {
   })
 
   it('should return dash for formattedDate when date is null or invalid', () => {
-    mockStore.routingSlip.createdOn = null as unknown as string
+    mockStore.routingSlip.routingSlipDate = null as unknown as string
     const composable1 = useRoutingSlipInfo()
     expect(composable1.formattedDate.value).toBe('-')
 
-    mockStore.routingSlip.createdOn = 'invalid-date'
+    mockStore.routingSlip.routingSlipDate = 'invalid-date'
     const composable2 = useRoutingSlipInfo()
     expect(composable2.formattedDate.value).toBe('-')
   })

--- a/web/pay-ui/tests/unit/utils/common-util.spec.ts
+++ b/web/pay-ui/tests/unit/utils/common-util.spec.ts
@@ -16,6 +16,13 @@ describe('common-util', () => {
     it.each([
       [new Date('2025-09-26T10:00:00.000Z'), undefined, 'Sep 26, 2025'],
       [new Date('2025-09-26T10:00:00.000Z'), 'yyyy-MM-dd', '2025-09-26'],
+      // date only values must not be shifted into the previous day by the Pacific conversion
+      ['2026-08-04', undefined, 'Aug 04, 2026'],
+      ['2026-08-04', 'MMMM dd, yyyy', 'August 04, 2026'],
+      ['2026-08-04', 'yyyy-MM-dd', '2026-08-04'],
+      // values carrying a time are still displayed in Pacific time
+      ['2026-08-04T21:40:50+00:00', undefined, 'Aug 04, 2026'],
+      ['2026-08-04T03:00:00+00:00', undefined, 'Aug 03, 2026'],
       ['invalid-date', undefined, ''],
       [null as unknown as Date | string, undefined, ''],
       [undefined as unknown as Date | string, undefined, '']


### PR DESCRIPTION
*Issue #:* https://github.com/bcgov/entity/issues/34476

*Description of changes:*
Date only values were parsed as UTC instants and shifted to Pacific time, pushing them into the previous day. Parse them in Pacific time instead, and point the routing slip detail Date at routingSlipDate rather than createdOn.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the pay-ui license (Apache 2.0).
